### PR TITLE
Add action branding

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,10 @@
 name: "FlyCI Wingman"
 description: "Automatically Fix Your Failing CI Builds"
 
+branding:
+  icon: check-circle
+  color: purple
+
 runs:
   using: "node20"
   main: "dist/index.js"


### PR DESCRIPTION
Use GitHub's built in branding badge until we got certified for Technology Partners and recieve our own custom icon.